### PR TITLE
Allow higher generator-karma versions than 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "yeoman-generator": "~0.13.0"
   },
   "peerDependencies": {
-    "generator-karma": "~0.5.0",
+    "generator-karma": ">=0.5.0",
     "yo": ">=1.0.0-rc.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Resolves install issue if generator-karma version is >0.5.0 (currently at 0.6.0), fixes #7.
