### PR TITLE
fix(app): update grunt-contrib-imagemin to v1.0.1

### DIFF
--- a/templates/common/_package.json
+++ b/templates/common/_package.json
@@ -14,7 +14,7 @@
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-htmlmin": "~0.4.0",
-    "grunt-contrib-imagemin": "~0.9.3",
+    "grunt-contrib-imagemin": "~1.0.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-autoprefixer": "~2.2.0",
     "grunt-usemin": "~3.0.0",


### PR DESCRIPTION
When generating "app", npm install fails due to gifsicle dependency in grunt-contrib-imagemin.
Current released version of generator-angular-ui-router relies on v0.2.0,
which has been known to cause issues when building.

Closes #21

Please release a new version of generator-angular-ui-router with this fix to Bower so that future users are able to use it without it crashing.
